### PR TITLE
Changes to airflow docker and docker-compose files for Mac compatibility

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -4,6 +4,6 @@ ARG CURRENT_USER=$USER
 
 USER root
 # Install Python dependencies to be able to process the wheels from the private PyPI server.
-RUN apt-get -y update && apt-get -y upgrade
+RUN apt-get -y update && ACCEPT_EULA=Y apt-get -y upgrade
 RUN apt-get install -y python3.9-distutils python3.9-dev build-essential
 USER ${CURRENT_USER}

--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -91,6 +91,7 @@ x-airflow-common:
 services:
   postgres:
     image: postgres:13
+    platform: linux/amd64
     environment:
       POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow
@@ -301,6 +302,7 @@ services:
 
   my-private-pypi:
     image: pypiserver/pypiserver:v1.5.2
+    platform: linux/amd64
     restart: always
     ports:
       - "80:8080"


### PR DESCRIPTION
Hi there,

I am on an Apple Silicon M2 and ran into two issues.

1.  Initializing the Airflow database with ‘docker compose up airflow-init’ gave an error related to accept EULA (see screenshot). 

<img width="1204" alt="Screenshot 2024-02-11 at 14 45 43" src="https://github.com/iusztinpaul/energy-forecasting/assets/18496483/ed582bf6-5288-49da-a231-632559000a57">
  
Changed the docker compose file to include ACCEPT_EULA=Y  like so: `RUN apt-get -y update && ACCEPT_EULA=Y apt-get -y upgrade`

2. Second error occurs with the next command: ‘docker compose --env-file .env up --build -d’ (see screenshot). 

<img width="550" alt="Screenshot 2024-02-11 at 14 45 28" src="https://github.com/iusztinpaul/energy-forecasting/assets/18496483/98d28ba3-dd50-4f1a-a8be-59413eb2fab3">

Fixed it by adding ‘platform: linux/amd64’ in docker-compose.yaml under  ‘services: postgres:’ and ‘my-private-pypi:’

Hope these are useful.
